### PR TITLE
added version locking for dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-selenium~=3.141.0
-PyAutoGui
+selenium==3.141.0
+PyAutoGUI==0.9.50


### PR DESCRIPTION
Whenever you have to add dependencies, never add manually.
run this command, it will version lock the dependencies to make a requirements.txt file
`pip freeze > requirements.txt`